### PR TITLE
feat: add .pipe() for forwarding events between emitters

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,29 @@ const payload = await emitter.wait("user:login");
 console.log(payload.id);
 ```
 
+### Pipe (Event Forwarding)
+
+Compose emitters by piping events from one to another.
+
+```ts
+const source = new Emitter<Events>();
+const sink = new Emitter<Events>();
+
+// Forward all events
+const sub = source.pipe(sink);
+
+// Forward specific events only
+source.pipe(sink, ["user:login", "user:logout"]);
+
+// Forward by wildcard pattern
+source.pipe(sink, "user:*");
+
+// Disconnect the pipe
+sub.off();
+```
+
+Pipes can be chained: `a.pipe(b)` then `b.pipe(c)` forwards events from `a` through `b` to `c`.
+
 ## API Reference
 
 ### `new Emitter<T>()`
@@ -166,6 +189,15 @@ Number of listeners for a specific event (excludes wildcards).
 ### `.eventNames(): string[]`
 
 Array of event names with registered listeners (excludes wildcards).
+
+### `.pipe(target, filter?): Subscription`
+
+Forward events to another emitter. `filter` can be:
+- omitted — forward all events
+- `string[]` — forward only the listed event names
+- `string` — forward events matching a wildcard pattern
+
+Returns a `Subscription` whose `off()` disconnects the pipe.
 
 ### `.clear(event?): this`
 


### PR DESCRIPTION
## Summary

- Add `.pipe(target)` to forward all events from one emitter to another
- Add `.pipe(target, events)` to forward specific events by name
- Add `.pipe(target, pattern)` to forward events matching a wildcard pattern
- Returns a `Subscription` handle to disconnect the pipe
- Pipes are cleaned up on `dispose()`
- 12 new tests covering all overloads, chaining, disconnection, and `emitAsync`
- README updated with usage section and API reference

Closes #2

## Test plan

- [x] `pipe(target)` forwards all events
- [x] `pipe(target, events)` forwards only listed events
- [x] `pipe(target, pattern)` forwards by wildcard (single and double)
- [x] `sub.off()` disconnects the pipe
- [x] `off()` is idempotent
- [x] `dispose()` cleans up pipes
- [x] Works with `emitAsync()`
- [x] Multiple pipes coexist
- [x] Pipe chains (source → middle → sink)

🤖 Generated with [Claude Code](https://claude.com/claude-code)