### PR TITLE
feat: add onError handler for listener exception isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,27 @@ emitter.on("data:save", async (record) => {
 await emitter.emitAsync("data:save", record);
 ```
 
+### Error Handling
+
+By default, if a listener throws, the error propagates and stops subsequent listeners from firing. Pass an `onError` handler to catch errors per-listener, allowing remaining listeners to still execute.
+
+```ts
+const emitter = new Emitter<Events>({
+  onError: (err, event) => console.error(`Error in ${event}:`, err),
+});
+
+emitter.on("save", () => {
+  throw new Error("db failure");
+});
+emitter.on("save", () => {
+  console.log("still runs");
+});
+
+emitter.emit("save", record); // both listeners are called
+```
+
+This works for both `emit()` and `emitAsync()`.
+
 ### Pause & Resume
 
 Buffer events while paused, replay them on resume.
@@ -141,9 +162,13 @@ Pipes can be chained: `a.pipe(b)` then `b.pipe(c)` forwards events from `a` thro
 
 ## API Reference
 
-### `new Emitter<T>()`
+### `new Emitter<T>(options?)`
 
 Create a new emitter. `T` is an `EventMap` — a record of event names to payload types.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `onError` | `(error: unknown, event: string) => void` | `undefined` | Called when a listener throws. When set, errors are caught per-listener so remaining listeners still execute. |
 
 ### `.on(event, listener, options?): Subscription`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,18 @@ interface StoredListener<T = unknown> {
   priority: number;
 }
 
+/**
+ * Options for constructing an `Emitter`.
+ */
+export interface EmitterOptions {
+  /**
+   * Called when a listener throws during `emit()` or `emitAsync()`.
+   * When set, errors are caught per-listener so remaining listeners
+   * still execute. When unset, errors propagate normally.
+   */
+  onError?: (error: unknown, event: string) => void;
+}
+
 // -- Wildcard Matching ----------------------------------------------------
 
 /**
@@ -122,6 +134,14 @@ export function matchWildcard(pattern: string, event: string): boolean {
  *
  * emitter.emit("user:login", { id: "42" });
  * ```
+ *
+ * @example
+ * ```ts
+ * // With error handling:
+ * const emitter = new Emitter<Events>({
+ *   onError: (err, event) => console.error(`Error in ${event}:`, err),
+ * });
+ * ```
  */
 export class Emitter<T extends EventMap = EventMap> {
   /** @internal */
@@ -144,6 +164,13 @@ export class Emitter<T extends EventMap = EventMap> {
 
   /** @internal */
   private pipeHandlers: ((event: string, payload: unknown) => void)[] = [];
+
+  /** @internal */
+  private onError?: (error: unknown, event: string) => void;
+
+  constructor(options?: EmitterOptions) {
+    this.onError = options?.onError;
+  }
 
   // -- Configuration ----------------------------------------------------
 
@@ -524,7 +551,15 @@ export class Emitter<T extends EventMap = EventMap> {
     if (listeners.length === 0) return false;
 
     for (const stored of listeners) {
-      stored.fn(payload);
+      if (this.onError) {
+        try {
+          stored.fn(payload);
+        } catch (err) {
+          this.onError(err, event);
+        }
+      } else {
+        stored.fn(payload);
+      }
     }
 
     this.pruneOnce(event, listeners);
@@ -541,7 +576,15 @@ export class Emitter<T extends EventMap = EventMap> {
     if (listeners.length === 0) return false;
 
     for (const stored of listeners) {
-      await stored.fn(payload);
+      if (this.onError) {
+        try {
+          await stored.fn(payload);
+        } catch (err) {
+          this.onError(err, event);
+        }
+      } else {
+        await stored.fn(payload);
+      }
     }
 
     this.pruneOnce(event, listeners);

--- a/tests/emitter.test.ts
+++ b/tests/emitter.test.ts
@@ -560,4 +560,122 @@ describe("Emitter", () => {
       expect(fn).toHaveBeenCalledWith("chained");
     });
   });
+
+  // -- onError ----------------------------------------------------------
+
+  describe("onError", () => {
+    test("catches listener error and calls onError handler", () => {
+      const errors: { err: unknown; event: string }[] = [];
+      const emitter = new Emitter<{ ping: string }>({
+        onError: (err, event) => errors.push({ err, event }),
+      });
+
+      const boom = new Error("boom");
+      emitter.on("ping", () => {
+        throw boom;
+      });
+      emitter.emit("ping", "hello");
+
+      expect(errors).toEqual([{ err: boom, event: "ping" }]);
+    });
+
+    test("remaining listeners still fire after a listener throws", () => {
+      const errors: unknown[] = [];
+      const emitter = new Emitter<{ ping: string }>({
+        onError: (err) => errors.push(err),
+      });
+
+      const order: number[] = [];
+      emitter.on("ping", () => order.push(1));
+      emitter.on("ping", () => {
+        throw new Error("fail");
+      });
+      emitter.on("ping", () => order.push(3));
+
+      emitter.emit("ping", "hello");
+
+      expect(order).toEqual([1, 3]);
+      expect(errors.length).toBe(1);
+    });
+
+    test("without onError, listener errors propagate normally", () => {
+      const emitter = new Emitter<{ ping: string }>();
+
+      emitter.on("ping", () => {
+        throw new Error("boom");
+      });
+
+      expect(() => emitter.emit("ping", "hello")).toThrow("boom");
+    });
+
+    test("onError works with emitAsync", async () => {
+      const errors: { err: unknown; event: string }[] = [];
+      const emitter = new Emitter<{ task: string }>({
+        onError: (err, event) => errors.push({ err, event }),
+      });
+
+      const order: number[] = [];
+      emitter.on("task", async () => order.push(1));
+      emitter.on("task", async () => {
+        throw new Error("async fail");
+      });
+      emitter.on("task", async () => order.push(3));
+
+      await emitter.emitAsync("task", "go");
+
+      expect(order).toEqual([1, 3]);
+      expect(errors.length).toBe(1);
+      expect((errors[0].err as Error).message).toBe("async fail");
+      expect(errors[0].event).toBe("task");
+    });
+
+    test("without onError, emitAsync errors propagate normally", async () => {
+      const emitter = new Emitter<{ task: string }>();
+
+      emitter.on("task", async () => {
+        throw new Error("async boom");
+      });
+
+      await expect(emitter.emitAsync("task", "go")).rejects.toThrow("async boom");
+    });
+
+    test("onError isolates errors between multiple listeners", () => {
+      const errors: unknown[] = [];
+      const emitter = new Emitter<{ ping: string }>({
+        onError: (err) => errors.push(err),
+      });
+
+      emitter.on("ping", () => {
+        throw new Error("first");
+      });
+      emitter.on("ping", () => {
+        throw new Error("second");
+      });
+
+      emitter.emit("ping", "hello");
+
+      expect(errors.length).toBe(2);
+      expect((errors[0] as Error).message).toBe("first");
+      expect((errors[1] as Error).message).toBe("second");
+    });
+
+    test("once listeners still get pruned when onError is set", () => {
+      const errors: unknown[] = [];
+      const emitter = new Emitter<{ ping: string }>({
+        onError: (err) => errors.push(err),
+      });
+
+      const fn = mock(() => {
+        throw new Error("once-error");
+      });
+      emitter.once("ping", fn);
+
+      emitter.emit("ping", "a");
+      emitter.emit("ping", "b");
+
+      // once listener should fire only once even though it threw
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(errors.length).toBe(1);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds an `onError` callback option to the `Emitter` constructor that catches per-listener errors during `emit()` and `emitAsync()`, allowing remaining listeners to still execute.
- Without `onError`, errors propagate normally (backward compatible).
- Adds 7 new tests covering error isolation, async errors, multiple throwing listeners, and once-listener pruning with errors.
- Documents the new option in README with usage example and API reference.

Closes #1

## Test plan

- [x] `bun test` passes (39 tests, 0 failures)
- [ ] Verify `onError` catches sync listener errors
- [ ] Verify `onError` catches async listener errors
- [ ] Verify remaining listeners still fire after a throw
- [ ] Verify errors propagate normally without `onError` (backward compat)
- [ ] Verify once-listeners are pruned even when they throw

🤖 Generated with [Claude Code](https://claude.com/claude-code)