### PR TITLE
feat: add middleware/interceptor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,39 @@ emitter.emit("save", record); // both listeners are called
 
 This works for both `emit()` and `emitAsync()`.
 
+### Middleware
+
+Intercept events before they reach listeners. Middleware can log, transform payloads, or swallow events entirely.
+
+```ts
+// Logging — passes events through unchanged
+emitter.use((event, payload, next) => {
+  console.log(`[${new Date().toISOString()}] ${event}`);
+  return next(payload);
+});
+
+// Filtering — swallow events by not calling next()
+emitter.use((event, payload, next) => {
+  if (event === "spam") return; // swallowed
+  return next(payload);
+});
+
+// Transform — modify the payload before listeners see it
+emitter.use((event, payload, next) => {
+  return next({ ...payload, timestamp: Date.now() });
+});
+```
+
+Middleware runs in registration order. Each calls `next(payload)` to continue the chain, or `next()` to pass the original payload through. Omit the `next()` call to swallow the event.
+
+```ts
+// Remove middleware later
+const sub = emitter.use(myMiddleware);
+sub.off();
+```
+
+Works with both `emit()` and `emitAsync()`. Async middleware is awaited when using `emitAsync()`.
+
 ### Pause & Resume
 
 Buffer events while paused, replay them on resume.
@@ -182,6 +215,18 @@ Subscribe to an event. Returns a `Subscription` with an `off()` method.
 ### `.once(event, listener, options?): Subscription`
 
 Shorthand for `.on(event, listener, { once: true })`.
+
+### `.use(middleware): Subscription`
+
+Register a middleware that intercepts events before listeners. Returns a `Subscription` whose `off()` removes it.
+
+```ts
+type Middleware = (
+  event: string,
+  payload: unknown,
+  next: (payload?: unknown) => void | Promise<void>,
+) => void | Promise<void>;
+```
 
 ### `.emit(event, payload): boolean`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,35 @@ export type EventMap = Record<string, unknown>;
 export type Listener<T = unknown> = (payload: T) => void | Promise<void>;
 
 /**
+ * A middleware function that intercepts events before they reach listeners.
+ *
+ * Middleware receives the event name, payload, and a `next` function.
+ * - Call `next()` to pass the original payload through.
+ * - Call `next(newPayload)` to transform the payload.
+ * - Don't call `next()` to swallow the event entirely.
+ *
+ * @example
+ * ```ts
+ * // Logging middleware
+ * const logger: Middleware = (event, payload, next) => {
+ *   console.log(`[${event}]`, payload);
+ *   return next(payload);
+ * };
+ *
+ * // Filtering middleware
+ * const filter: Middleware = (event, payload, next) => {
+ *   if (event === "spam") return; // swallow
+ *   return next(payload);
+ * };
+ * ```
+ */
+export type Middleware = (
+  event: string,
+  payload: unknown,
+  next: (payload?: unknown) => void | Promise<void>,
+) => void | Promise<void>;
+
+/**
  * Options for subscribing to events.
  */
 export interface OnOptions {
@@ -166,6 +195,9 @@ export class Emitter<T extends EventMap = EventMap> {
   private pipeHandlers: ((event: string, payload: unknown) => void)[] = [];
 
   /** @internal */
+  private middlewares: Middleware[] = [];
+
+  /** @internal */
   private onError?: (error: unknown, event: string) => void;
 
   constructor(options?: EmitterOptions) {
@@ -200,6 +232,49 @@ export class Emitter<T extends EventMap = EventMap> {
   setMaxBufferSize(n: number): this {
     this.maxBufferSize = n;
     return this;
+  }
+
+  // -- Middleware -------------------------------------------------------
+
+  /**
+   * Register a middleware that intercepts events before they reach listeners.
+   * Middleware runs in registration order. Each middleware receives the event
+   * name, payload, and a `next` function to continue the chain.
+   *
+   * - Call `next()` to pass the original payload through.
+   * - Call `next(newPayload)` to transform the payload before listeners see it.
+   * - Don't call `next()` to swallow the event entirely (listeners won't fire).
+   *
+   * Returns a `Subscription` whose `off()` removes the middleware.
+   *
+   * @example
+   * ```ts
+   * // Logging
+   * emitter.use((event, payload, next) => {
+   *   console.log(`[${new Date().toISOString()}] ${event}`);
+   *   return next(payload);
+   * });
+   *
+   * // Filtering
+   * emitter.use((event, payload, next) => {
+   *   if (event === "spam") return; // swallow
+   *   return next(payload);
+   * });
+   *
+   * // Transform
+   * emitter.use((event, payload, next) => {
+   *   return next({ ...payload, timestamp: Date.now() });
+   * });
+   * ```
+   */
+  use(middleware: Middleware): Subscription {
+    this.middlewares.push(middleware);
+    return {
+      off: () => {
+        const idx = this.middlewares.indexOf(middleware);
+        if (idx !== -1) this.middlewares.splice(idx, 1);
+      },
+    };
   }
 
   // -- Subscribe --------------------------------------------------------
@@ -478,6 +553,7 @@ export class Emitter<T extends EventMap = EventMap> {
     this.listeners.clear();
     this.wildcardListeners = [];
     this.pipeHandlers = [];
+    this.middlewares = [];
     this.buffer = [];
     this.paused = false;
   }
@@ -548,17 +624,39 @@ export class Emitter<T extends EventMap = EventMap> {
     }
 
     const listeners = this.collectListeners(event);
+    if (listeners.length === 0 && this.middlewares.length === 0) return false;
+
+    let finalPayload = payload;
+    let swallowed = false;
+
+    if (this.middlewares.length > 0) {
+      swallowed = true;
+      let idx = 0;
+      const chain = (p: unknown): void => {
+        if (idx < this.middlewares.length) {
+          const mw = this.middlewares[idx++];
+          mw(event, p, (next?: unknown) => chain(next !== undefined ? next : p));
+        } else {
+          swallowed = false;
+          finalPayload = p;
+        }
+      };
+      chain(payload);
+
+      if (swallowed) return false;
+    }
+
     if (listeners.length === 0) return false;
 
     for (const stored of listeners) {
       if (this.onError) {
         try {
-          stored.fn(payload);
+          stored.fn(finalPayload);
         } catch (err) {
           this.onError(err, event);
         }
       } else {
-        stored.fn(payload);
+        stored.fn(finalPayload);
       }
     }
 
@@ -573,17 +671,39 @@ export class Emitter<T extends EventMap = EventMap> {
     }
 
     const listeners = this.collectListeners(event);
+    if (listeners.length === 0 && this.middlewares.length === 0) return false;
+
+    let finalPayload = payload;
+    let swallowed = false;
+
+    if (this.middlewares.length > 0) {
+      swallowed = true;
+      let idx = 0;
+      const chain = async (p: unknown): Promise<void> => {
+        if (idx < this.middlewares.length) {
+          const mw = this.middlewares[idx++];
+          await mw(event, p, async (next?: unknown) => chain(next !== undefined ? next : p));
+        } else {
+          swallowed = false;
+          finalPayload = p;
+        }
+      };
+      await chain(payload);
+
+      if (swallowed) return false;
+    }
+
     if (listeners.length === 0) return false;
 
     for (const stored of listeners) {
       if (this.onError) {
         try {
-          await stored.fn(payload);
+          await stored.fn(finalPayload);
         } catch (err) {
           this.onError(err, event);
         }
       } else {
-        await stored.fn(payload);
+        await stored.fn(finalPayload);
       }
     }
 

--- a/tests/emitter.test.ts
+++ b/tests/emitter.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, mock } from "bun:test";
-import { Emitter, matchWildcard } from "../src/index";
+import { Emitter, matchWildcard, type Middleware } from "../src/index";
 
 // -- matchWildcard --------------------------------------------------------
 
@@ -676,6 +676,303 @@ describe("Emitter", () => {
       // once listener should fire only once even though it threw
       expect(fn).toHaveBeenCalledTimes(1);
       expect(errors.length).toBe(1);
+    });
+  });
+
+  // -- Middleware --------------------------------------------------------
+
+  describe("middleware", () => {
+    test("use() returns a subscription that removes the middleware", () => {
+      const emitter = new Emitter<{ ping: string }>();
+      const calls: string[] = [];
+
+      const sub = emitter.use((event, payload, next) => {
+        calls.push("mw");
+        return next(payload);
+      });
+      emitter.on("ping", (v) => calls.push(v));
+
+      emitter.emit("ping", "a");
+      expect(calls).toEqual(["mw", "a"]);
+
+      sub.off();
+      calls.length = 0;
+
+      emitter.emit("ping", "b");
+      expect(calls).toEqual(["b"]);
+    });
+
+    test("middleware runs before listeners", () => {
+      const emitter = new Emitter<{ ping: string }>();
+      const order: string[] = [];
+
+      emitter.use((event, payload, next) => {
+        order.push("middleware");
+        return next(payload);
+      });
+      emitter.on("ping", () => order.push("listener"));
+
+      emitter.emit("ping", "hello");
+
+      expect(order).toEqual(["middleware", "listener"]);
+    });
+
+    test("middleware can transform the payload", () => {
+      const emitter = new Emitter<{ ping: string }>();
+      const fn = mock(() => {});
+
+      emitter.use((_event, _payload, next) => {
+        return next("transformed");
+      });
+      emitter.on("ping", fn);
+
+      emitter.emit("ping", "original");
+
+      expect(fn).toHaveBeenCalledWith("transformed");
+    });
+
+    test("middleware can swallow events by not calling next()", () => {
+      const emitter = new Emitter<{ ping: string }>();
+      const fn = mock(() => {});
+
+      emitter.use((_event, _payload, _next) => {
+        // intentionally not calling next
+      });
+      emitter.on("ping", fn);
+
+      const result = emitter.emit("ping", "hello");
+
+      expect(fn).toHaveBeenCalledTimes(0);
+      expect(result).toBe(false);
+    });
+
+    test("middleware can selectively swallow events", () => {
+      const emitter = new Emitter();
+      const fn = mock(() => {});
+
+      emitter.use((event, payload, next) => {
+        if (event === "spam") return; // swallow
+        return next(payload);
+      });
+      emitter.on("ping", fn);
+      emitter.on("spam", fn);
+
+      emitter.emit("ping", "ok");
+      emitter.emit("spam", "blocked");
+
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(fn).toHaveBeenCalledWith("ok");
+    });
+
+    test("multiple middleware run in registration order", () => {
+      const emitter = new Emitter<{ ping: number }>();
+      const order: number[] = [];
+
+      emitter.use((_event, payload, next) => {
+        order.push(1);
+        return next(payload);
+      });
+      emitter.use((_event, payload, next) => {
+        order.push(2);
+        return next(payload);
+      });
+      emitter.use((_event, payload, next) => {
+        order.push(3);
+        return next(payload);
+      });
+      emitter.on("ping", () => order.push(4));
+
+      emitter.emit("ping", 0);
+
+      expect(order).toEqual([1, 2, 3, 4]);
+    });
+
+    test("middleware chain passes transformed payload through", () => {
+      const emitter = new Emitter<{ count: number }>();
+      const fn = mock(() => {});
+
+      emitter.use((_event, payload, next) => {
+        return next((payload as number) + 1);
+      });
+      emitter.use((_event, payload, next) => {
+        return next((payload as number) * 10);
+      });
+      emitter.on("count", fn);
+
+      emitter.emit("count", 1); // 1 -> +1 = 2 -> *10 = 20
+
+      expect(fn).toHaveBeenCalledWith(20);
+    });
+
+    test("later middleware can swallow after earlier ones passed through", () => {
+      const emitter = new Emitter<{ ping: string }>();
+      const fn = mock(() => {});
+
+      emitter.use((_event, payload, next) => next(payload));
+      emitter.use((_event, _payload, _next) => {
+        // swallow
+      });
+      emitter.on("ping", fn);
+
+      emitter.emit("ping", "hello");
+
+      expect(fn).toHaveBeenCalledTimes(0);
+    });
+
+    test("middleware works with emitAsync", async () => {
+      const emitter = new Emitter<{ task: string }>();
+      const order: string[] = [];
+
+      emitter.use(async (event, payload, next) => {
+        order.push("mw-start");
+        await new Promise((r) => setTimeout(r, 5));
+        order.push("mw-end");
+        return next(payload);
+      });
+      emitter.on("task", () => order.push("listener"));
+
+      await emitter.emitAsync("task", "go");
+
+      expect(order).toEqual(["mw-start", "mw-end", "listener"]);
+    });
+
+    test("async middleware can transform payload", async () => {
+      const emitter = new Emitter<{ task: string }>();
+      const fn = mock(() => {});
+
+      emitter.use(async (_event, _payload, next) => {
+        await new Promise((r) => setTimeout(r, 1));
+        return next("async-transformed");
+      });
+      emitter.on("task", fn);
+
+      await emitter.emitAsync("task", "original");
+
+      expect(fn).toHaveBeenCalledWith("async-transformed");
+    });
+
+    test("async middleware can swallow events", async () => {
+      const emitter = new Emitter<{ task: string }>();
+      const fn = mock(() => {});
+
+      emitter.use(async (_event, _payload, _next) => {
+        await new Promise((r) => setTimeout(r, 1));
+        // swallow
+      });
+      emitter.on("task", fn);
+
+      const result = await emitter.emitAsync("task", "go");
+
+      expect(fn).toHaveBeenCalledTimes(0);
+      expect(result).toBe(false);
+    });
+
+    test("dispose() clears middleware", () => {
+      const emitter = new Emitter<{ ping: string }>();
+      const fn = mock(() => {});
+      const mwFn = mock((_e: string, _p: unknown, next: Function) => next());
+
+      emitter.use(mwFn as unknown as Middleware);
+      emitter.on("ping", fn);
+      emitter.dispose();
+
+      emitter.on("ping", fn);
+      emitter.emit("ping", "after-dispose");
+
+      expect(mwFn).toHaveBeenCalledTimes(0);
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    test("middleware works with wildcard listeners", () => {
+      const emitter = new Emitter();
+      const fn = mock(() => {});
+
+      emitter.use((_event, _payload, next) => next("intercepted"));
+      emitter.on("user:*", fn);
+
+      emitter.emit("user:login", "original");
+
+      expect(fn).toHaveBeenCalledWith("intercepted");
+    });
+
+    test("middleware works with pause/resume", () => {
+      const emitter = new Emitter<{ ping: string }>();
+      const fn = mock(() => {});
+
+      emitter.use((_event, payload, next) => next(`${payload}!`));
+      emitter.on("ping", fn);
+
+      emitter.pause();
+      emitter.emit("ping", "buffered");
+      emitter.resume();
+
+      expect(fn).toHaveBeenCalledWith("buffered!");
+    });
+
+    test("middleware works with once listeners", () => {
+      const emitter = new Emitter<{ ping: string }>();
+      const fn = mock(() => {});
+
+      emitter.use((_event, payload, next) => next(payload));
+      emitter.once("ping", fn);
+
+      emitter.emit("ping", "a");
+      emitter.emit("ping", "b");
+
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(fn).toHaveBeenCalledWith("a");
+    });
+
+    test("middleware works with onError", () => {
+      const errors: unknown[] = [];
+      const emitter = new Emitter<{ ping: string }>({
+        onError: (err) => errors.push(err),
+      });
+
+      emitter.use((_event, payload, next) => next(payload));
+      emitter.on("ping", () => { throw new Error("boom"); });
+      emitter.on("ping", () => {}); // should still fire
+
+      emitter.emit("ping", "hello");
+
+      expect(errors.length).toBe(1);
+    });
+
+    test("middleware off() is idempotent", () => {
+      const emitter = new Emitter();
+      const sub = emitter.use((_e, _p, next) => next());
+      sub.off();
+      sub.off(); // should not throw
+    });
+
+    test("next() with no argument passes original payload", () => {
+      const emitter = new Emitter<{ ping: string }>();
+      const fn = mock(() => {});
+
+      emitter.use((_event, _payload, next) => next());
+      emitter.on("ping", fn);
+
+      emitter.emit("ping", "original");
+
+      expect(fn).toHaveBeenCalledWith("original");
+    });
+
+    test("emit returns false when middleware swallows and no listeners", () => {
+      const emitter = new Emitter<{ ping: string }>();
+
+      emitter.use((_event, _payload, _next) => {
+        // swallow
+      });
+
+      expect(emitter.emit("ping", "hello")).toBe(false);
+    });
+
+    test("emit returns true when middleware passes through to listeners", () => {
+      const emitter = new Emitter<{ ping: string }>();
+      emitter.use((_event, payload, next) => next(payload));
+      emitter.on("ping", () => {});
+
+      expect(emitter.emit("ping", "hello")).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Adds `.use(middleware)` method for registering middleware that intercepts events before listeners
- Middleware can transform payloads via `next(newPayload)`, pass through via `next()`, or swallow events by not calling `next()`
- Middleware runs in registration order, building a chain before listeners fire
- Works with both `emit()` and `emitAsync()` — async middleware is properly awaited
- `dispose()` clears middleware; `.use()` returns a `Subscription` for removal
- 20 new tests covering all middleware behaviors (transform, swallow, chain, async, integration with wildcards/pause/once/onError)
- README updated with usage docs and API reference

Closes #4

## Test plan
- [x] All 70 tests pass (50 existing + 20 new)
- [x] TypeScript compiles cleanly
- [ ] CI passes
- [ ] @0xLeif review

🤖 Generated with [Claude Code](https://claude.com/claude-code)